### PR TITLE
Fix bug when open blockscout.com/eth_rpc_api_docs

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -67,7 +67,7 @@ frontend explorer
     #Check for network type
     acl is_poa path_beg -i /poa
     acl is_etc path_beg -i /etc
-    acl is_eth path_beg -i /eth
+    acl is_eth path_beg -i /eth/
     acl is_lukso path_beg -i /lukso
 #    acl is_aerum path_beg -i /aerum
 #    acl is_callisto path_beg -i /callisto


### PR DESCRIPTION
This PR fixes a bug when a user in chain A and they try to open RPC API docs page `blockscout.com/eth_rpc_api_docs`, `acl is_eth path_beg -i /eth` is triggered. Together with cookie for chain A we get to https://github.com/blockscout/haproxy-config/blob/04c120ab2f365cbbbf9155adc49e7012ca354235/haproxy.cfg#L196 causing haproxy navigates to a default instance